### PR TITLE
Add support for running ro-crate-html-lite in a container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Create and publish Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=sha
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:25.6.1@sha256:75c416c7d966e4684e58afa091a86c9a01b16c610e46d8e40c5563df18e9623a
+
+COPY . /ro-crate-html-lite
+WORKDIR /ro-crate-html-lite
+RUN npm install
+
+# Don't run as root user
+RUN useradd app
+USER app
+
+ENTRYPOINT ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25.6.1@sha256:75c416c7d966e4684e58afa091a86c9a01b16c610e46d8e40c5563df18e9623a
+FROM --platform=$BUILDPLATFORM node:25.6.1
 
 COPY . /ro-crate-html-lite
 WORKDIR /ro-crate-html-lite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM --platform=$BUILDPLATFORM node:25.6.1
 
+LABEL org.opencontainers.image.source=https://github.com/Language-Research-Technology/ro-crate-html-lite
+LABEL org.opencontainers.image.description="ro-crate-html-lite: A tool to create a complete, completely static ro-crate-preview.html file."
+LABEL org.opencontainers.image.licenses="GPL-3.0"
+
 COPY . /ro-crate-html-lite
 WORKDIR /ro-crate-html-lite
 RUN npm install


### PR DESCRIPTION
Hello!
I am looking for a portable and reproducible way to run ro-crate-html-lite without relying on having node installed on my system. I have created a Dockerfile that packages the tool into a docker image using [node](https://hub.docker.com/_/node) as the base image.

I've also added a github actions job for building and hosting the image on github if you are interested in supporting that at the repository level.

I would be interested in any feedback you might have with this approach. You can see the images that get built on my fork here: https://github.com/aringeri/ro-crate-html-lite/pkgs/container/ro-crate-html-lite