### PR TITLE
fix url encode issue 45

### DIFF
--- a/template.html
+++ b/template.html
@@ -692,12 +692,12 @@
               {%- if item.content %}
                 {{ item.content | renderMarkdown | safe }}
               {%- else %}
-                <p>Markdown content not available. <a href="{{ item.id | urlencode }}">View file</a></p>
+                <p>Markdown content not available. <a href="{{ item.id }}">View file</a></p>
               {%- endif %}
             {% elif pdfRegex.test(item.id) %}
               <!--          <iframe   src="{{ item.id }}" type="application/pdf" width="100%" height="600px" loading="lazy" />-->
             {%- endif %}
-            <a href="{{ item.id | urlencode }}">Open file location</a>
+            <a href="{{ item.id }}">Open file location</a>
           </div>
         {%- endif %}
 

--- a/template.js
+++ b/template.js
@@ -769,7 +769,7 @@ t_38 += runtime.suppressValue(env.getFilter("safe").call(context, env.getFilter(
 }
 else {
 t_38 += "\n                <p>Markdown content not available. <a href=\"";
-t_38 += runtime.suppressValue(env.getFilter("urlencode").call(context, runtime.memberLookup((l_item),"id")), env.opts.autoescape);
+t_38 += runtime.suppressValue(runtime.memberLookup((l_item),"id"), env.opts.autoescape);
 t_38 += "\">View file</a></p>";
 ;
 }
@@ -794,7 +794,7 @@ t_38 += "\" type=\"application/pdf\" width=\"100%\" height=\"600px\" loading=\"l
 ;
 }
 t_38 += "\n            <a href=\"";
-t_38 += runtime.suppressValue(env.getFilter("urlencode").call(context, runtime.memberLookup((l_item),"id")), env.opts.autoescape);
+t_38 += runtime.suppressValue(runtime.memberLookup((l_item),"id"), env.opts.autoescape);
 t_38 += "\">Open file location</a>\n          </div>";
 ;
 }


### PR DESCRIPTION
file paths in template.html (line 695 and 700) are url encoded, which converts `/` to `%2F` and breaks the "open file location" links

this fix removes the url encode from lines 695 and 700 in template.html and rebuilds the template.js file